### PR TITLE
Add helpers to convert from VAVAILABILITY to slots and back

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,11 @@
       "name": "@nextcloud/calendar-availability-vue",
       "version": "0.1.0",
       "license": "MIT",
+      "dependencies": {
+        "ical.js": "^1.4.0",
+        "icalzone": "^0.0.1",
+        "uuid": "^8.3.2"
+      },
       "devDependencies": {
         "@babel/core": "^7.16.0",
         "@babel/preset-env": "^7.16.4",
@@ -4387,8 +4392,12 @@
     "node_modules/ical.js": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/ical.js/-/ical.js-1.4.0.tgz",
-      "integrity": "sha512-ltHZuOFNNjcyEYbzDgjemS7LWIFh2vydJeznxQHUh3dnarbxqOYsWONYteBVAq1MEOHnwXFGN2eskZReHclnrA==",
-      "dev": true
+      "integrity": "sha512-ltHZuOFNNjcyEYbzDgjemS7LWIFh2vydJeznxQHUh3dnarbxqOYsWONYteBVAq1MEOHnwXFGN2eskZReHclnrA=="
+    },
+    "node_modules/icalzone": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/icalzone/-/icalzone-0.0.1.tgz",
+      "integrity": "sha512-ln0AM3fMSLLuJijuWuRzwrN0Tg+BG8ADi7ha6slmC7ZqOijagif5I6b4Nl4/vPSXWexnxyrHiEof8VxDOllXVQ=="
     },
     "node_modules/icss-replace-symbols": {
       "version": "1.1.0",
@@ -7373,7 +7382,6 @@
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true,
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -11085,8 +11093,12 @@
     "ical.js": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/ical.js/-/ical.js-1.4.0.tgz",
-      "integrity": "sha512-ltHZuOFNNjcyEYbzDgjemS7LWIFh2vydJeznxQHUh3dnarbxqOYsWONYteBVAq1MEOHnwXFGN2eskZReHclnrA==",
-      "dev": true
+      "integrity": "sha512-ltHZuOFNNjcyEYbzDgjemS7LWIFh2vydJeznxQHUh3dnarbxqOYsWONYteBVAq1MEOHnwXFGN2eskZReHclnrA=="
+    },
+    "icalzone": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/icalzone/-/icalzone-0.0.1.tgz",
+      "integrity": "sha512-ln0AM3fMSLLuJijuWuRzwrN0Tg+BG8ADi7ha6slmC7ZqOijagif5I6b4Nl4/vPSXWexnxyrHiEof8VxDOllXVQ=="
     },
     "icss-replace-symbols": {
       "version": "1.1.0",
@@ -13367,8 +13379,7 @@
     "uuid": {
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     },
     "v-click-outside": {
       "version": "3.1.2",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,11 @@
     "url": "https://github.com/nextcloud/calendar-availability-vue/issues"
   },
   "homepage": "https://github.com/nextcloud/calendar-availability-vue#readme",
+  "dependencies": {
+    "ical.js": "^1.4.0",
+    "icalzone": "^0.0.1",
+    "uuid": "^8.3.2"
+  },
   "devDependencies": {
     "@babel/core": "^7.16.0",
     "@babel/preset-env": "^7.16.4",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -28,7 +28,8 @@ export default {
     postcss(),
     commonjs(),
     babel({
-      babelHelpers: 'bundled'
+      babelHelpers: 'bundled',
+      presets: ["@babel/preset-env"]
     })
   ]
 }

--- a/src/convert.js
+++ b/src/convert.js
@@ -1,0 +1,129 @@
+import { getZoneString } from 'icalzone'
+import { parse as parseIcal, Component } from 'ical.js'
+import { v4 as uuidv4 } from 'uuid'
+
+export function getEmptySlots() {
+	return {
+		MO: [],
+		TU: [],
+		WE: [],
+		TH: [],
+		FR: [],
+		SA: [],
+		SU: [],
+	}
+}
+
+export function vavailabilityToSlots(vavailability) {
+    const parsedIcal = parseIcal(vavailability)
+
+	const vcalendarComp = new Component(parsedIcal)
+	const vavailabilityComp = vcalendarComp.getFirstSubcomponent('vavailability')
+
+	let timezoneId
+	const timezoneComp = vcalendarComp.getFirstSubcomponent('vtimezone')
+	if (timezoneComp) {
+		timezoneId = timezoneComp.getFirstProperty('tzid').getFirstValue()
+	}
+
+	const availableComps = vavailabilityComp.getAllSubcomponents('available')
+	// Combine all AVAILABLE blocks into a week of slots
+	const slots = getEmptySlots()
+	availableComps.forEach((availableComp) => {
+		const start = availableComp.getFirstProperty('dtstart').getFirstValue().toJSDate()
+		const end = availableComp.getFirstProperty('dtend').getFirstValue().toJSDate()
+		const rrule = availableComp.getFirstProperty('rrule')
+
+		if (rrule.getFirstValue().freq !== 'WEEKLY') {
+			logger.warn('rrule not supported', {
+				rrule: rrule.toICALString(),
+			})
+			return
+		}
+
+		rrule.getFirstValue().getComponent('BYDAY').forEach(day => {
+			slots[day].push({
+				start: start.getTime() / 1000,
+				end: end.getTime() / 1000,
+			})
+		})
+	})
+
+	return {
+		slots,
+		timezoneId,
+	}
+}
+
+export function slotsToVavailability(slots, timezoneId) {
+    const vcalendarComp = new ICAL.Component('vcalendar')
+	vcalendarComp.addPropertyWithValue('prodid', 'Nextcloud DAV app')
+
+	// Store time zone info
+	// If possible we use the info from a time zone database
+	const predefinedTimezoneIcal = getZoneString(timezoneId)
+	if (predefinedTimezoneIcal) {
+		const timezoneComp = new ICAL.Component(ICAL.parse(predefinedTimezoneIcal))
+		vcalendarComp.addSubcomponent(timezoneComp)
+	} else {
+		// Fall back to a simple markup
+		const timezoneComp = new ICAL.Component('vtimezone')
+		timezoneComp.addPropertyWithValue('tzid', timezoneId)
+		vcalendarComp.addSubcomponent(timezoneComp)
+	}
+
+	// Store availability info
+	const vavailabilityComp = new ICAL.Component('vavailability')
+
+	// Deduplicate by start and end time
+	const deduplicated = slots.reduce((acc, slot) => {
+		const start = new Date(slot.start * 1000)
+		const end = new Date(slot.end * 1000)
+
+		const key = [
+			start.getHours(),
+			start.getMinutes(),
+			end.getHours(),
+			end.getMinutes(),
+		].join('-')
+
+		return {
+			...acc,
+			[key]: [...(acc[key] ?? []), slot],
+		}
+	}, {})
+
+	// Create an AVAILABILITY component for every recurring slot
+	Object.keys(deduplicated).map(key => {
+		const slots = deduplicated[key]
+		const start = slots[0].start
+		const end = slots[0].end
+		// Combine days but make them also unique
+		const days = slots.map(slot => slot.day).filter((day, index, self) => self.indexOf(day) === index)
+
+		const availableComp = new ICAL.Component('available')
+
+		// Define DTSTART and DTEND
+		const startTimeProp = availableComp.addPropertyWithValue('dtstart', ICAL.Time.fromJSDate(new Date(start * 1000), false))
+		startTimeProp.setParameter('tzid', timezoneId)
+		const endTimeProp = availableComp.addPropertyWithValue('dtend', ICAL.Time.fromJSDate(new Date(end * 1000), false))
+		endTimeProp.setParameter('tzid', timezoneId)
+
+		// Add mandatory UID
+		availableComp.addPropertyWithValue('uid', uuidv4())
+
+		// TODO: add optional summary
+
+		// Define RRULE
+		availableComp.addPropertyWithValue('rrule', {
+			freq: 'WEEKLY',
+			byday: days,
+		})
+
+		return availableComp
+	}).map(vavailabilityComp.addSubcomponent.bind(vavailabilityComp))
+
+	vcalendarComp.addSubcomponent(vavailabilityComp)
+
+    return vcalendarComp.toString()
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,9 @@
 import CalendarAvailability from './CalendarAvailability.vue'
+import { getEmptySlots, slotsToVavailability, vavailabilityToSlots } from './convert'
 
-export { CalendarAvailability }
+export {
+    CalendarAvailability,
+    getEmptySlots,
+    slotsToVavailability,
+    vavailabilityToSlots,
+}


### PR DESCRIPTION
Confirmed to work with https://github.com/nextcloud/server/pull/29796

- [x] Adapt to https://github.com/nextcloud/calendar-availability-vue/pull/7 – replace js date objects with unix time stamps