### PR TITLE
Bump @nextcloud/vue from 4.2.0 to 5.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@nextcloud/browserslist-config": "^2.2.0",
         "@nextcloud/eslint-plugin": "^2.0.0",
         "@nextcloud/l10n": "^1.4.1",
-        "@nextcloud/vue": "^4.2.0",
+        "@nextcloud/vue": "^5.0.0",
         "@rollup/plugin-babel": "^5.3.0",
         "@rollup/plugin-commonjs": "^21.0.1",
         "@rollup/plugin-node-resolve": "^13.0.6",
@@ -1817,17 +1817,17 @@
       "dev": true
     },
     "node_modules/@nextcloud/calendar-js": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/calendar-js/-/calendar-js-2.0.0.tgz",
-      "integrity": "sha512-wGDDWjnXaMTJVxK2B31S0BAstN5759fptuddWRVZcFU2gEFXZyiv0iFgcbCOdAni+/Mz9rBbdV8h+TYWbst6Qg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/calendar-js/-/calendar-js-3.0.0.tgz",
+      "integrity": "sha512-Uy/etWwRmbzG1jxcfampOCEXbGMEzY1xVCBlONVrkusUmD9t02u3jWFkRJGAHvFAtLd4iM+MdTo1x3VXemBvcA==",
       "dev": true,
-      "dependencies": {
-        "ical.js": "^1.4.0",
-        "uuid": "^8.3.2"
-      },
       "engines": {
         "node": ">=14.0.0",
         "npm": ">=7.0.0"
+      },
+      "peerDependencies": {
+        "ical.js": "^1.4.0",
+        "uuid": "^8.3.2"
       }
     },
     "node_modules/@nextcloud/capabilities": {
@@ -1957,15 +1957,15 @@
       }
     },
     "node_modules/@nextcloud/vue": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-4.2.0.tgz",
-      "integrity": "sha512-i7VZIrfpDcK7/0ZmCU+C7j+pXd4LyxAZpxxu/FS4rJJWR1IolgjGVlBbu8q1NxX0FLc4/xUVj4lv3vyMSdrUOA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-5.0.0.tgz",
+      "integrity": "sha512-hqfI3n3mebi7dlLUBjyBzIJQJTVjtFrCm49KYo2lQ/qDzBzOf5hrjwEEM3tnQIiPtHU8k24CnoSNqYto9XzERg==",
       "dev": true,
       "dependencies": {
         "@nextcloud/auth": "^1.2.3",
         "@nextcloud/axios": "^1.3.2",
         "@nextcloud/browser-storage": "^0.1.1",
-        "@nextcloud/calendar-js": "^2.0.0",
+        "@nextcloud/calendar-js": "^3.0.0",
         "@nextcloud/capabilities": "^1.0.2",
         "@nextcloud/dialogs": "^3.0.0",
         "@nextcloud/event-bus": "^2.0.0",
@@ -1987,14 +1987,14 @@
         "v-tooltip": "^2.0.3",
         "vue": "^2.6.11",
         "vue-color": "^2.7.1",
-        "vue-material-design-icons": "^4.11.0",
+        "vue-material-design-icons": "^5.0.0",
         "vue-multiselect": "^2.1.6",
         "vue-visible": "^1.0.2",
         "vue2-datepicker": "^3.6.3"
       },
       "engines": {
-        "node": ">=14.0.0",
-        "npm": ">=7.0.0"
+        "node": "^14.0.0",
+        "npm": "^7.0.0"
       }
     },
     "node_modules/@nicolo-ribaudo/chokidar-2": {
@@ -7460,9 +7460,9 @@
       }
     },
     "node_modules/vue-material-design-icons": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/vue-material-design-icons/-/vue-material-design-icons-4.13.0.tgz",
-      "integrity": "sha512-TwaWrvh4J49VdkV9Uzcbr/p3FBRiBthRkIrg6SUh7ogFUljdA2ySNoAYD9dTU+mJkANIn1A6MoD/PnyLONnkWg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/vue-material-design-icons/-/vue-material-design-icons-5.0.0.tgz",
+      "integrity": "sha512-lYSJFW/TyQqmg7MvUbEB8ua1mwWy/v8qve7QJuA/UWUAXC4/yVUdAm4pg/sM9+k5n7VLckBv6ucOROuGBsGPDQ==",
       "dev": true
     },
     "node_modules/vue-multiselect": {
@@ -9004,14 +9004,11 @@
       "dev": true
     },
     "@nextcloud/calendar-js": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/calendar-js/-/calendar-js-2.0.0.tgz",
-      "integrity": "sha512-wGDDWjnXaMTJVxK2B31S0BAstN5759fptuddWRVZcFU2gEFXZyiv0iFgcbCOdAni+/Mz9rBbdV8h+TYWbst6Qg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/calendar-js/-/calendar-js-3.0.0.tgz",
+      "integrity": "sha512-Uy/etWwRmbzG1jxcfampOCEXbGMEzY1xVCBlONVrkusUmD9t02u3jWFkRJGAHvFAtLd4iM+MdTo1x3VXemBvcA==",
       "dev": true,
-      "requires": {
-        "ical.js": "^1.4.0",
-        "uuid": "^8.3.2"
-      }
+      "requires": {}
     },
     "@nextcloud/capabilities": {
       "version": "1.0.4",
@@ -9132,15 +9129,15 @@
       }
     },
     "@nextcloud/vue": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-4.2.0.tgz",
-      "integrity": "sha512-i7VZIrfpDcK7/0ZmCU+C7j+pXd4LyxAZpxxu/FS4rJJWR1IolgjGVlBbu8q1NxX0FLc4/xUVj4lv3vyMSdrUOA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-5.0.0.tgz",
+      "integrity": "sha512-hqfI3n3mebi7dlLUBjyBzIJQJTVjtFrCm49KYo2lQ/qDzBzOf5hrjwEEM3tnQIiPtHU8k24CnoSNqYto9XzERg==",
       "dev": true,
       "requires": {
         "@nextcloud/auth": "^1.2.3",
         "@nextcloud/axios": "^1.3.2",
         "@nextcloud/browser-storage": "^0.1.1",
-        "@nextcloud/calendar-js": "^2.0.0",
+        "@nextcloud/calendar-js": "^3.0.0",
         "@nextcloud/capabilities": "^1.0.2",
         "@nextcloud/dialogs": "^3.0.0",
         "@nextcloud/event-bus": "^2.0.0",
@@ -9162,7 +9159,7 @@
         "v-tooltip": "^2.0.3",
         "vue": "^2.6.11",
         "vue-color": "^2.7.1",
-        "vue-material-design-icons": "^4.11.0",
+        "vue-material-design-icons": "^5.0.0",
         "vue-multiselect": "^2.1.6",
         "vue-visible": "^1.0.2",
         "vue2-datepicker": "^3.6.3"
@@ -13448,9 +13445,9 @@
       }
     },
     "vue-material-design-icons": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/vue-material-design-icons/-/vue-material-design-icons-4.13.0.tgz",
-      "integrity": "sha512-TwaWrvh4J49VdkV9Uzcbr/p3FBRiBthRkIrg6SUh7ogFUljdA2ySNoAYD9dTU+mJkANIn1A6MoD/PnyLONnkWg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/vue-material-design-icons/-/vue-material-design-icons-5.0.0.tgz",
+      "integrity": "sha512-lYSJFW/TyQqmg7MvUbEB8ua1mwWy/v8qve7QJuA/UWUAXC4/yVUdAm4pg/sM9+k5n7VLckBv6ucOROuGBsGPDQ==",
       "dev": true
     },
     "vue-multiselect": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@nextcloud/browserslist-config": "^2.2.0",
     "@nextcloud/eslint-plugin": "^2.0.0",
     "@nextcloud/l10n": "^1.4.1",
-    "@nextcloud/vue": "^4.2.0",
+    "@nextcloud/vue": "^5.0.0",
     "@rollup/plugin-babel": "^5.3.0",
     "@rollup/plugin-commonjs": "^21.0.1",
     "@rollup/plugin-node-resolve": "^13.0.6",


### PR DESCRIPTION
Required for https://github.com/nextcloud/server/pull/29796

I didn't test yet.