### PR TITLE
Upgrade `@nextcloud/vue` to `^6.0.0 || ^7.1.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   },
   "peerDependencies": {
     "@nextcloud/l10n": "^1.4",
-    "@nextcloud/vue": "^6.0.0-beta.1||^7.0.0-beta.1",
+    "@nextcloud/vue": "^6.0.0 || ^7.1.0",
     "vue": "^2.7"
   },
   "browserslist": [


### PR DESCRIPTION
I'm not too sure, can you confirm @ChristophWurst ?

See https://github.com/nextcloud/server/pull/35179

```
npm ERR! code ERESOLVE
npm ERR! ERESOLVE could not resolve
npm ERR! 
npm ERR! While resolving: @nextcloud/calendar-availability-vue@0.5.0-beta.3
npm ERR! Found: @nextcloud/vue@7.1.0-beta.0
npm ERR! node_modules/@nextcloud/vue
npm ERR!   @nextcloud/vue@"^7.1.0-beta.0" from the root project
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peer @nextcloud/vue@"^6.0.0-beta.1||^7.0.0-beta.1" from @nextcloud/calendar-availability-vue@0.5.0-beta.3
npm ERR! node_modules/@nextcloud/calendar-availability-vue
npm ERR!   @nextcloud/calendar-availability-vue@"^0.5.0-beta.3" from the root project
npm ERR! 
npm ERR! Conflicting peer dependency: @nextcloud/vue@7.0.1
npm ERR! node_modules/@nextcloud/vue
npm ERR!   peer @nextcloud/vue@"^6.0.0-beta.1||^7.0.0-beta.1" from @nextcloud/calendar-availability-vue@0.5.0-beta.3
npm ERR!   node_modules/@nextcloud/calendar-availability-vue
npm ERR!     @nextcloud/calendar-availability-vue@"^0.5.0-beta.3" from the root project
npm ERR! 
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force, or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
npm ERR! 
npm ERR! See /home/admin/.npm/eresolve-report.txt for a full report.

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/admin/.npm/_logs/2022-11-15T14_17_24_226Z-debug-0.log
```