### PR TITLE
chore: add .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,5 @@
+/.github
+/src
+/*.tgz
+rollup.config.js
+.eslintrc*


### PR DESCRIPTION
Fix #64 

```
$ npm pack
npm notice
npm notice 📦  @nextcloud/calendar-availability-vue@0.5.0-rc2
npm notice === Tarball Contents ===
npm notice 717B    CHANGELOG.md
npm notice 1.1kB   LICENSE
npm notice 2.6kB   README.md
npm notice 469.9kB lib/index.esm.js
npm notice 980.1kB lib/index.esm.js.map
npm notice 470.4kB lib/index.js
npm notice 980.2kB lib/index.js.map
npm notice 1.9kB   package.json
npm notice === Tarball Details ===
npm notice name:          @nextcloud/calendar-availability-vue
npm notice version:       0.5.0-rc2
npm notice filename:      @nextcloud/calendar-availability-vue-0.5.0-rc2.tgz
npm notice package size:  507.4 kB
npm notice unpacked size: 2.9 MB
npm notice shasum:        3985a97abfadf4d5f1abf0cc0e9fb313b0a03fbf
npm notice integrity:     sha512-dkcldVhmC7+qc[...]6tKk8CazOrdAA==
npm notice total files:   8
npm notice
nextcloud-calendar-availability-vue-0.5.0-rc2.tgz
```