### PR TITLE
feat!: drop umd bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,7 @@
   "version": "0.6.0-alpha1",
   "description": "Weekly calendar availability component for Nextcloud apps",
   "type": "module",
-  "main": "dist/index.umd.cjs",
-  "module": "dist/index.js",
+  "main": "dist/index.js",
   "scripts": {
     "build": "vite build",
     "watch": "vite build --watch",

--- a/src/CalendarAvailability.vue
+++ b/src/CalendarAvailability.vue
@@ -51,8 +51,7 @@
 </template>
 
 <script>
-import NcDatetimePicker from '@nextcloud/vue/dist/Components/NcDatetimePicker.js'
-import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
+import { NcDatetimePicker, NcButton } from '@nextcloud/vue'
 import IconDelete from 'vue-material-design-icons/Delete.vue'
 import IconAdd from 'vue-material-design-icons/Plus.vue'
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -17,14 +17,10 @@ export default defineConfig({
       entry: 'src/index.js',
       name: packageJson.name,
       fileName: 'index',
+      formats: ['es']
     },
     rollupOptions: {
-      external: ['vue'],
-      output: {
-        globals: {
-          vue: 'Vue',
-        },
-      },
-    },
+      external: Object.keys(packageJson.peerDependencies)
+    }
   },
 })


### PR DESCRIPTION
This PR significantly reduces bundle size and fixes the library.

Currently, it completely breaks rendering calendar due to a dependency conflict caused by the UMD bundle. It is 2023 and this library is **only** targeted to be used with a bundler so we don't need to emit it anymore. We just need an ESM bundle to be used with a bundler (and to enable tree shaking). Please refer to the [official rollup docs](https://rollupjs.org/configuration-options/#output-format) for more info on this topic.

I also refactored all imports of nc-vue and externalized all peer dependencies. They don't need to be bundled with the lib as they are already bundled by apps consuming this library.

Ref https://github.com/nextcloud/calendar-availability-vue/pull/118#pullrequestreview-1474174962

**Before:** Library builds but calendar doesn't render anymore when linked
**After:** Library builds, is significantly smaller and calendar renders again

## Bundle size

### Before
```
vite v4.3.9 building for production...
✓ 383 modules transformed.
dist/index.js  1,990.79 kB │ gzip: 414.34 kB
dist/index.umd.cjs  1,397.22 kB │ gzip: 343.59 kB
✓ built in 3.65s
```

### After
```
vite v4.3.9 building for production...
✓ 350 modules transformed.
dist/index.js  339.21 kB │ gzip: 69.96 kB
✓ built in 1.24s
```
