### PR TITLE
chore(deps): bump @nextcloud-vue to v8.0.0-beta.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@nextcloud/browserslist-config": "^2.2.0",
         "@nextcloud/eslint-config": "^8.2.0",
         "@nextcloud/l10n": "^1.4 || ^2.0",
-        "@nextcloud/vue": "^6.0 || ^7.0",
+        "@nextcloud/vue": "^8.0.0-beta.1",
         "@vitejs/plugin-vue2": "^2.2.0",
         "browserslist-to-esbuild": "^1.2.0",
         "sass": "^1.57.1",
@@ -34,7 +34,7 @@
       },
       "peerDependencies": {
         "@nextcloud/l10n": "^1.4 || ^2.0",
-        "@nextcloud/vue": "^6.0 || ^7.0",
+        "@nextcloud/vue": ">=8.0.0-beta.0",
         "vue": "^2.7"
       }
     },
@@ -1223,9 +1223,9 @@
       }
     },
     "node_modules/@nextcloud/vue": {
-      "version": "7.12.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-7.12.0.tgz",
-      "integrity": "sha512-f7x3YFBzc/mt27F7AU+ITLmGCwRpVM0aVTF+DxjaOdelQNTYZBuFJCCOk6nC+x+gg/KWLIxeWm/NWDxToCstbQ==",
+      "version": "8.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.0.0-beta.1.tgz",
+      "integrity": "sha512-PfuvM2Ad/3Wk2MQXl6VcuO5TbslUunKqDAlDtyVjfu9fxPmLIb8Boga19TbMTr/9EMH4vsX2vEiEM3Q5C4thoQ==",
       "dev": true,
       "dependencies": {
         "@floating-ui/dom": "^1.1.0",
@@ -1243,13 +1243,13 @@
         "@nextcloud/vue-select": "^3.21.2",
         "@skjnldsv/sanitize-svg": "^1.0.2",
         "@vueuse/components": "^10.0.2",
+        "@vueuse/core": "^10.1.2",
         "clone": "^2.1.2",
         "debounce": "1.2.1",
         "emoji-mart-vue-fast": "^12.0.1",
         "escape-html": "^1.0.3",
         "floating-vue": "^1.0.0-beta.19",
         "focus-trap": "^7.1.0",
-        "hammerjs": "^2.0.8",
         "linkify-string": "^4.0.0",
         "md5": "^2.3.0",
         "node-polyfill-webpack-plugin": "^2.0.1",
@@ -4572,15 +4572,6 @@
       "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
       "dev": true,
       "peer": true
-    },
-    "node_modules/hammerjs": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/hammerjs/-/hammerjs-2.0.8.tgz",
-      "integrity": "sha1-BO93hiz/K7edMPdpIJWTAiK/YPE=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.8.0"
-      }
     },
     "node_modules/has": {
       "version": "1.0.3",
@@ -9436,9 +9427,9 @@
       }
     },
     "@nextcloud/vue": {
-      "version": "7.12.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-7.12.0.tgz",
-      "integrity": "sha512-f7x3YFBzc/mt27F7AU+ITLmGCwRpVM0aVTF+DxjaOdelQNTYZBuFJCCOk6nC+x+gg/KWLIxeWm/NWDxToCstbQ==",
+      "version": "8.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.0.0-beta.1.tgz",
+      "integrity": "sha512-PfuvM2Ad/3Wk2MQXl6VcuO5TbslUunKqDAlDtyVjfu9fxPmLIb8Boga19TbMTr/9EMH4vsX2vEiEM3Q5C4thoQ==",
       "dev": true,
       "requires": {
         "@floating-ui/dom": "^1.1.0",
@@ -9456,13 +9447,13 @@
         "@nextcloud/vue-select": "^3.21.2",
         "@skjnldsv/sanitize-svg": "^1.0.2",
         "@vueuse/components": "^10.0.2",
+        "@vueuse/core": "^10.1.2",
         "clone": "^2.1.2",
         "debounce": "1.2.1",
         "emoji-mart-vue-fast": "^12.0.1",
         "escape-html": "^1.0.3",
         "floating-vue": "^1.0.0-beta.19",
         "focus-trap": "^7.1.0",
-        "hammerjs": "^2.0.8",
         "linkify-string": "^4.0.0",
         "md5": "^2.3.0",
         "node-polyfill-webpack-plugin": "^2.0.1",
@@ -12018,12 +12009,6 @@
       "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
       "dev": true,
       "peer": true
-    },
-    "hammerjs": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/hammerjs/-/hammerjs-2.0.8.tgz",
-      "integrity": "sha1-BO93hiz/K7edMPdpIJWTAiK/YPE=",
-      "dev": true
     },
     "has": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@nextcloud/browserslist-config": "^2.2.0",
     "@nextcloud/eslint-config": "^8.2.0",
     "@nextcloud/l10n": "^1.4 || ^2.0",
-    "@nextcloud/vue": "^6.0 || ^7.0",
+    "@nextcloud/vue": "^8.0.0-beta.1",
     "@vitejs/plugin-vue2": "^2.2.0",
     "browserslist-to-esbuild": "^1.2.0",
     "sass": "^1.57.1",
@@ -50,7 +50,7 @@
   },
   "peerDependencies": {
     "@nextcloud/l10n": "^1.4 || ^2.0",
-    "@nextcloud/vue": "^6.0 || ^7.0",
+    "@nextcloud/vue": ">=8.0.0-beta.0",
     "vue": "^2.7"
   },
   "browserslist": [


### PR DESCRIPTION
Fix #117 

I had to remove the version skew as there are visual regressions when mixing nc-vue versions (at least for v7 and v8).