### PR TITLE
chore(release): v2.0.0-beta.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## 2.0.0-beta.2
+### Changed
+* Bump @nextcloud/vue peer dependency to >=8.0.0-beta.7
+* Dependencies updates
+### Removed
+* Support for @nextcloud/vue v8.0.0-beta.1 .. v8.0.0-beta.6
+
 ## 2.0.0-beta.1
 ### Changed
 * Bump @nextcloud/vue peer dependency to >=8.0.0-beta.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nextcloud/calendar-availability-vue",
-  "version": "2.0.0-beta.1",
+  "version": "2.0.0-beta.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nextcloud/calendar-availability-vue",
-      "version": "2.0.0-beta.1",
+      "version": "2.0.0-beta.2",
       "license": "MIT",
       "dependencies": {
         "@nextcloud/logger": "^2.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextcloud/calendar-availability-vue",
-  "version": "2.0.0-beta.1",
+  "version": "2.0.0-beta.2",
   "description": "Weekly calendar availability component for Nextcloud apps",
   "type": "module",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   },
   "peerDependencies": {
     "@nextcloud/l10n": "^1.4 || ^2.0",
-    "@nextcloud/vue": ">=8.0.0-beta.0",
+    "@nextcloud/vue": ">=8.0.0-beta.7",
     "vue": "^2.7"
   },
   "browserslist": [


### PR DESCRIPTION
## 2.0.0-beta.2
### Changed
* Bump @nextcloud/vue peer dependency to >=8.0.0-beta.7
* Dependencies updates
### Removed
* Support for @nextcloud/vue v8.0.0-beta.1 .. v8.0.0-beta.6