### PR TITLE
chore(vue3): remove dead styles containing deprecated ::v-deep syntax

### DIFF
--- a/src/CalendarAvailability.vue
+++ b/src/CalendarAvailability.vue
@@ -251,16 +251,6 @@ export default {
 	display: flex;
 	flex-direction: column;
 }
-::v-deep .mx-input-wrapper {
-	width: 85px;
-}
-::v-deep .mx-datepicker {
-	width: 97px;
-}
-::v-deep .multiselect {
-	border: 1px solid var(--color-border-dark);
-	width: 120px;
-}
 .time-zone {
 	padding: 32px 12px 12px 0;
 }


### PR DESCRIPTION
Fix https://github.com/nextcloud/calendar-availability-vue/issues/212

I searched for those classes in the source code and rendered HTML. They are dead because we neither use the mx-datepicker nor the multiselect component any longer.