### PR TITLE
release: v2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
-## [2.0.1](https://github.com/nextcloud/calendar-availability-vue/compare/v2.0.0...v2.0.1) (2023-12-11)
+# [2.1.0](https://github.com/nextcloud/calendar-availability-vue/compare/v2.0.1...v2.1.0) (2024-02-09)
 
+### Build
+
+* **chore:** update npm engines version to 10.0.0 (https://github.com/nextcloud/calendar-availability-vue/pull/213)
+* **build:** migrate to `@nextcloud/vite-config` and externalize `@nextcloud/vue` (https://github.com/nextcloud/calendar-availability-vue/pull/225)
+* **deps:** bump `@nextcloud/vue` to v8.6.2 (https://github.com/nextcloud/calendar-availability-vue/pull/224)
+
+# [2.0.1](https://github.com/nextcloud/calendar-availability-vue/compare/v2.0.0...v2.0.1) (2023-12-11)
 
 ### Bug Fixes
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nextcloud/calendar-availability-vue",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nextcloud/calendar-availability-vue",
-      "version": "2.0.1",
+      "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
         "@nextcloud/logger": "^2.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextcloud/calendar-availability-vue",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "Weekly calendar availability component for Nextcloud apps",
   "type": "module",
   "module": "dist/index.mjs",


### PR DESCRIPTION
# [2.1.0](https://github.com/nextcloud/calendar-availability-vue/compare/v2.0.1...v2.1.0) (2024-02-09)

### Build

* **chore:** update npm engines version to 10.0.0 (https://github.com/nextcloud/calendar-availability-vue/pull/213)
* **build:** migrate to `@nextcloud/vite-config` and externalize `@nextcloud/vue` (https://github.com/nextcloud/calendar-availability-vue/pull/225)
* **deps:** bump `@nextcloud/vue` to v8.6.2 (https://github.com/nextcloud/calendar-availability-vue/pull/224)
