### PR TITLE
fix: changed aria-labels on weekday list, only on ul container now

### DIFF
--- a/src/CalendarAvailability.vue
+++ b/src/CalendarAvailability.vue
@@ -1,5 +1,5 @@
 <template>
-	<ul class="week-day-container" aria-label="List of weekdays">
+	<ul class="week-day-container" :aria-label="l10nWeekDayListLabel">
 		<template v-for="day in internalSlots">
 			<li :key="`day-label-${day.id}`" class="day-container">
 				<div class="label-weekday">
@@ -99,6 +99,10 @@ export default {
 		l10nAddSlot: {
 			type: String,
 			required: true,
+		},
+		l10nWeekDayListLabel: {
+			type: String,
+			default: 'Weekdays',
 		},
 		l10nMonday: {
 			type: String,

--- a/src/CalendarAvailability.vue
+++ b/src/CalendarAvailability.vue
@@ -1,7 +1,7 @@
 <template>
-	<ul class="week-day-container">
+	<ul class="week-day-container" aria-label="List of weekdays">
 		<template v-for="day in internalSlots">
-			<li :key="`day-label-${day.id}`" class="day-container" :aria-labelledby="day.displayName + '-label'">
+			<li :key="`day-label-${day.id}`" class="day-container">
 				<div class="label-weekday">
 					<span :id="day.displayName + '-label'">{{ day.displayName }}</span>
 				</div>


### PR DESCRIPTION
* Resolves nextcloud-gmbh/accessibility#4

## Reasoning and Summary
* The `li` elements in the calendar component should not have the aria labelledby attributes. Instead, what would be more accessible is if just the `ul` wrapper had an aria label

## View
![firefox_rKWQH2q5WV](https://github.com/nextcloud/calendar-availability-vue/assets/110193237/eb518f5e-feed-41f0-a15c-74776865df94)
