### PR TITLE
fix: time shifting when parsing slots

### DIFF
--- a/src/convert.js
+++ b/src/convert.js
@@ -43,9 +43,16 @@ export function vavailabilityToSlots(vavailability) {
 	// Combine all AVAILABLE blocks into a week of slots
 	const slots = getEmptySlots()
 	availableComps.forEach((availableComp) => {
-		const start = availableComp.getFirstProperty('dtstart').getFirstValue().toJSDate()
-		const end = availableComp.getFirstProperty('dtend').getFirstValue().toJSDate()
+		const startIcalDate = availableComp.getFirstProperty('dtstart').getFirstValue()
+		const endIcalDate = availableComp.getFirstProperty('dtend').getFirstValue()
 		const rrule = availableComp.getFirstProperty('rrule')
+
+		// Prevent date to be converted to local time zone (and to be shifted by the utc offset).
+		// Instead, set hh:mm directly as if they are in the component's time zone.
+		const start = new Date()
+		start.setHours(startIcalDate.hour, startIcalDate.minute, 0, 0)
+		const end = new Date()
+		end.setHours(endIcalDate.hour, endIcalDate.minute, 0, 0)
 
 		if (rrule.getFirstValue().freq !== 'WEEKLY') {
 			logger.warn('rrule not supported', {


### PR DESCRIPTION
Fix https://github.com/nextcloud/server/issues/50016

Every time the settings are parsed, the timezone offset is added to all slots.

## How to reproduce?

1. Save some slots in a time zone other than UTC.
2. Reload the page.
3. Observe that the UTC offset was added to the slots.

## Screencasts

### Before

https://github.com/user-attachments/assets/a2c43b07-a853-421d-8f50-369421f4c9ec

### After

https://github.com/user-attachments/assets/512d60ed-df24-4783-b5f0-39552902de55