### PR TITLE
chore(readme): add support column to version matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ Weekly calendar availability component for Nextcloud apps
 
 ## Compatibility matrix
 
-`@nextcloud/calendar-availability-vue` | `@nextcloud/vue`
----------------------------------------|-----------------
-1.x.x                                  | 6.x.x. and 7.x.x
-2.x.x                                  | 8.x.x
+`@nextcloud/calendar-availability-vue` | `@nextcloud/vue` | Status
+---------------------------------------|------------------|----------
+1.x.x                                  | 6.x.x. and 7.x.x | EOL
+2.x.x                                  | 8.x.x            | Supported
 
 ## Slots data structure
 


### PR DESCRIPTION
We don't need to do release for `stable1.0` any longer.

Nobody is downloading them anyway:
![image](https://github.com/user-attachments/assets/78edd692-d18d-4ccb-9363-0ea3b99cb6c5)
