### PR TITLE
[stable2.2] fix: use outline delete icon

### DIFF
--- a/src/CalendarAvailability.vue
+++ b/src/CalendarAvailability.vue
@@ -66,7 +66,7 @@
 <script>
 import NcDateTimePickerNative from '@nextcloud/vue/dist/Components/NcDateTimePickerNative.js'
 import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
-import IconDelete from 'vue-material-design-icons/Delete.vue'
+import IconDelete from 'vue-material-design-icons/DeleteOutline.vue'
 import IconAdd from 'vue-material-design-icons/Plus.vue'
 
 import { getFirstDay } from '@nextcloud/l10n'


### PR DESCRIPTION
Manual backport of https://github.com/nextcloud/calendar-availability-vue/pull/419