### PR TITLE
[stable2.2] chore: use trashcan outline

### DIFF
--- a/src/CalendarAvailability.vue
+++ b/src/CalendarAvailability.vue
@@ -66,7 +66,7 @@
 <script>
 import NcDateTimePickerNative from '@nextcloud/vue/dist/Components/NcDateTimePickerNative.js'
 import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
-import IconDelete from 'vue-material-design-icons/DeleteOutline.vue'
+import IconDelete from 'vue-material-design-icons/TrashCanOutline.vue'
 import IconAdd from 'vue-material-design-icons/Plus.vue'
 
 import { getFirstDay } from '@nextcloud/l10n'


### PR DESCRIPTION
Manual backport of https://github.com/nextcloud/calendar-availability-vue/pull/425

Note: This will also bring the outlined icon to stable31 and stable30 (if we merge the dependency updates).